### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_utils.yml
+++ b/.github/workflows/test_utils.yml
@@ -1,5 +1,8 @@
 name: CI - Test Utils
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, prepare-to-collaborate]


### PR DESCRIPTION
Potential fix for [https://github.com/diegoabeltran16/GRACE-vector/security/code-scanning/1](https://github.com/diegoabeltran16/GRACE-vector/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only needs to check out the repository and run tests, the `contents: read` permission is sufficient. This change will ensure that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
